### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/flask_app/__init__.py
+++ b/flask_app/__init__.py
@@ -43,7 +43,7 @@ def parse_authorized_response(resp):
     print(type(resp))
     print(resp)
     if resp is None:
-        return 'Access denied: reason=%s error=%s' % (
+        return 'Access denied: reason={0!s} error={1!s}'.format(
             request.args['error_reason'],
             request.args['error_description']
         )

--- a/flask_app/controller.py
+++ b/flask_app/controller.py
@@ -4,4 +4,4 @@ from flask_app import fapp
 
 @fapp.route('/<page>', defaults={'page': 'index'})
 def main(page):
-    return render_template('pages/%s.html' % page)
+    return render_template('pages/{0!s}.html'.format(page))


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:matt3o:Eve-OAuth2-Example-Application?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:matt3o:Eve-OAuth2-Example-Application?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)